### PR TITLE
Attempt to sort non-valid version numbers

### DIFF
--- a/server.rb
+++ b/server.rb
@@ -95,7 +95,7 @@ class CraneOp < Sinatra::Base
   def sort_versions(ary)
     valid_version_numbers = ary.select { |i| i if i.match(/^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+(-[[:alnum:]]+)?$/) }
     non_valid_version_numbers = ary - valid_version_numbers
-    versions = valid_version_numbers.sort_by {|v| Gem::Version.new( v.gsub(/^[a-z|A-Z|.]*/, '') ) } + non_valid_version_numbers
+    versions = valid_version_numbers.sort_by {|v| Gem::Version.new( v.gsub(/^[a-z|A-Z|.]*/, '') ) } + non_valid_version_numbers.sort
     if versions.include?('latest')
       # Make sure 'latest' appears at the top of the list
       versions.delete('latest')


### PR DESCRIPTION
I have no Ruby skills, but from a super quick Google this might work - just to attempt to sort based on defaults for other tag version names