### PR TITLE
Docker should handle installing dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,11 @@
 FROM ruby:2.3.1
 MAINTAINER Mike Heijmans <parabuzzle@gmail.com>
 
+RUN apt-get update && \
+    apt-get install python-software-properties -y && \
+    curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
+    apt-get install nodejs -y
+
 # Add env variables
 ENV PORT 80
 ENV REGISTRY_HOST localhost
@@ -20,6 +25,10 @@ WORKDIR $APP_HOME
 
 # Add the app
 ADD . $APP_HOME
+
+RUN gem install httparty memoist && \
+    npm install && \
+    node_modules/.bin/webpack
 
 RUN gem update bundler
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,19 +5,14 @@
 FROM ruby:2.3.1
 MAINTAINER Mike Heijmans <parabuzzle@gmail.com>
 
-RUN apt-get update && \
-    apt-get install python-software-properties -y && \
-    curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
-    apt-get install nodejs -y
-
 # Add env variables
-ENV PORT 80
-ENV REGISTRY_HOST localhost
-ENV REGISTRY_PORT=5000
-ENV REGISTRY_PROTO=https
-ENV REGISTRY_SSL_VERIFY=true
-ENV REGISTRY_ALLOW_DELETE=false
-ENV APP_HOME=/webapp
+ENV PORT=80 \
+    REGISTRY_HOST=localhost \
+    REGISTRY_PORT=5000 \
+    REGISTRY_PROTO=https \
+    REGISTRY_SSL_VERIFY=true \
+    REGISTRY_ALLOW_DELETE=false \
+    APP_HOME=/webapp
 
 RUN mkdir -p $APP_HOME
 # switch to the application directory for exec commands
@@ -26,9 +21,15 @@ WORKDIR $APP_HOME
 # Add the app
 ADD . $APP_HOME
 
-RUN gem install httparty memoist && \
+RUN apt-get update && \
+    apt-get install python-software-properties -y && \
+    curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
+    apt-get install nodejs -y && \
     npm install && \
-    node_modules/.bin/webpack
+    node_modules/.bin/webpack && \
+    rm -rf node_modules && \
+    apt-get purge nodejs python-software-properties -y && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN gem update bundler
 

--- a/Rakefile
+++ b/Rakefile
@@ -34,9 +34,6 @@ end
 
 desc "Build Container"
 task :build do
-  sh "npm install"
-  sh "npm install webpack"
-  sh "node_modules/webpack/bin/webpack.js"
   sh "docker build -t parabuzzle/craneoperator:latest ."
 end
 


### PR DESCRIPTION
From my point of view the docker container should handle installing the dependencies without "polluting" the host system with the installed dependencies. 

Like this it is not necessary to have node, rake, etc. installed on the host system to still be able to build a new docker container. :)