### PR TITLE
Refactor to multi-stage build and latest ruby container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,26 @@
 #
 # https://docs.docker.com/reference/builder/
 
-FROM ruby:2.3.6-alpine
-MAINTAINER Mike Heijmans <parabuzzle@gmail.com>
+FROM ruby:2.4.4-alpine3.6 as builder
+ENV APP_HOME=/webapp
 
-# Add env variables
+RUN mkdir -p $APP_HOME
+# switch to the application directory for exec commands
+WORKDIR $APP_HOME
+
+# Add the app
+COPY . $APP_HOME
+
+RUN apk add --update nodejs nodejs-npm g++ musl-dev make linux-headers && \
+    npm install --no-optional && \
+    node_modules/.bin/webpack && \
+    rm -rf node_modules && \
+    gem update bundler && \
+    bundle install --deployment
+
+FROM ruby:2.4.4-alpine3.6
+LABEL maintainer="Mike Heijmans <parabuzzle@gmail.com>"
+
 ENV PORT=80 \
     REGISTRY_HOST=localhost \
     REGISTRY_PORT=5000 \
@@ -18,16 +34,9 @@ RUN mkdir -p $APP_HOME
 # switch to the application directory for exec commands
 WORKDIR $APP_HOME
 
-# Add the app
-COPY . $APP_HOME
+COPY --from=builder ${APP_HOME} .
 
-RUN apk add --update nodejs g++ musl-dev make linux-headers && \
-    npm install --no-optional && \
-    node_modules/.bin/webpack && \
-    rm -rf node_modules && \
-    gem update bundler && \
-    bundle install --deployment && \
-    apk del nodejs g++ musl-dev make linux-headers
+RUN bundle install --deployment
 
 # Run the app
 CMD ["bundle", "exec", "foreman", "start"]

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.3.6'
+ruby '2.4.4'
 
 # Server requirements
 gem 'thin' # or mongrel


### PR DESCRIPTION
Hi @parabuzzle 
I was experimenting around with multi stage builds in docker and I'm quite satisfied with the results of it. When using the new Dockerfile the image `uncompressed` image size of craneoperator drops from 388MB down to 124MB 

I'm not a really sure why I need the `bundle install` in the "running"-container. If I don't put it there, in complains that some gems need to be installed first although they are all available in the `vendor/` folder. Maybe you can give me some input on that, since I'm not familiar with ruby/gem!? 

Other than that everythings seems to be working fine on my machine 🙂  