### PR TITLE
fix for long passwords

### DIFF
--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -34,7 +34,7 @@ module Helpers
   end
 
   def base64_docker_auth(username, password)
-    Base64.encode64("#{username}:#{password}").chomp
+    Base64.strict_encode64("#{username}:#{password}")
   end
 
   def append_header(headers, addl_header)


### PR DESCRIPTION
i ran into a little bug, where the password obviously exceeded the linewrap threshold, as i am tryiing to follow NIST guidelines on passwords.
this resulted in a line wrap in the middle of the encoded string, thus invalidating the password. the chomp only removes the whitespaces before an after. strict mode does help with not even adding line feeds.