### PR TITLE
update ruby minor patch levels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # https://docs.docker.com/reference/builder/
 
-FROM ruby:2.6.0-alpine
+FROM ruby:2.6.8-alpine
 MAINTAINER Mike Heijmans <parabuzzle@gmail.com>
 
 # Add env variables
@@ -20,6 +20,8 @@ WORKDIR $APP_HOME
 
 # Add the app
 COPY . $APP_HOME
+
+RUN apk upgrade --available && sync
 
 RUN apk add --update nodejs g++ musl-dev make linux-headers yarn && \
     yarn install && \

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.6.0'
+ruby '2.6.8'
 
 # Server requirements
 gem 'thin' # or mongrel

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,30 +1,29 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    coderay (1.1.2)
-    daemons (1.3.1)
+    coderay (1.1.3)
+    daemons (1.4.1)
     eventmachine (1.2.7)
-    foreman (0.85.0)
-      thor (~> 0.19.1)
-    httparty (0.16.4)
+    foreman (0.87.2)
+    httparty (0.20.0)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
-    kgio (2.11.2)
-    memoist (0.16.0)
-    method_source (0.9.2)
-    mime-types (3.2.2)
+    kgio (2.11.4)
+    memoist (0.16.2)
+    method_source (1.0.0)
+    mime-types (3.4.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2018.0812)
+    mime-types-data (3.2021.1115)
     multi_xml (0.6.0)
-    oj (3.7.9)
-    pry (0.12.2)
-      coderay (~> 1.1.0)
-      method_source (~> 0.9.0)
-    rack (1.6.11)
+    oj (3.13.9)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    rack (1.6.13)
     rack-protection (1.5.5)
       rack
-    raindrops (0.19.0)
-    rake (12.3.2)
+    raindrops (0.19.2)
+    rake (13.0.6)
     sinatra (1.4.8)
       rack (~> 1.5)
       rack-protection (~> 1.4)
@@ -32,17 +31,16 @@ GEM
     sinatra-cross_origin (0.3.2)
     sinatra-session (1.0.0)
       sinatra (>= 1.0)
-    slim (4.0.1)
+    slim (4.1.0)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 2.0.6, < 2.1)
-    temple (0.8.0)
-    thin (1.7.2)
+    temple (0.8.2)
+    thin (1.8.1)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
       rack (>= 1, < 3)
-    thor (0.19.4)
-    tilt (2.0.9)
-    unicorn (5.4.1)
+    tilt (2.0.10)
+    unicorn (6.0.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)
 
@@ -66,7 +64,7 @@ DEPENDENCIES
   unicorn
 
 RUBY VERSION
-   ruby 2.6.0p0
+   ruby 2.6.8p205
 
 BUNDLED WITH
    1.17.2


### PR DESCRIPTION
I was getting a TLS error when connecting to a registry that requires `TLSv1.3` so I updated the ruby installation and Gems and that seemed to do the trick