### PR TITLE
Add arm64 platform build

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -34,7 +34,7 @@ end
 
 desc "Build Container"
 task :build do
-  sh "docker build --platform linux/amd64,linux/arm64 -t parabuzzle/craneoperator:latest ."
+  sh "docker buildx build --platform linux/amd64,linux/arm64 -t parabuzzle/craneoperator:latest ."
 end
 
 task :default => [:build]

--- a/Rakefile
+++ b/Rakefile
@@ -34,7 +34,7 @@ end
 
 desc "Build Container"
 task :build do
-  sh "docker build -t parabuzzle/craneoperator:latest ."
+  sh "docker build --platform linux/amd64,linux/arm64 -t parabuzzle/craneoperator:latest ."
 end
 
 task :default => [:build]


### PR DESCRIPTION
As described in Issue #69, it would be nice if there were arm64 builds in addition to the amd64 ones so that craneoperator could be run in the Raspberry Pi.  Therefore this PR adds the `--platform` flag to the docker build as defined by [v1.4 of the docker API](https://docs.docker.com/engine/api/v1.40/#operation/ImageBuild) and utilizes buildx [as described here](https://www.docker.com/blog/multi-platform-docker-builds/) to allow both arm64 and amd64 builds to be generated at the same time.

If I've gotten something wrong here just let me know or feel free to ignore this PR (as I don't have access to CircleCI I can't exactly test this).